### PR TITLE
Block aliases

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "author": "JeanJPNM",
   "license": "ISC",
-  "packageManager": "pnpm",
+  "packageManager": "pnpm@7.0.0",
   "dependencies": {
     "canvas": "^2.9.0",
     "pako": "^2.0.4",

--- a/src/mindustry/block/block.ts
+++ b/src/mindustry/block/block.ts
@@ -3,6 +3,7 @@ import {
   BlockOutput,
   BlockOutputDirection,
   BlockRenderingOptions,
+  blockAliases,
 } from './helper'
 import { RenderingInfo, ticksPerSecond, translatePos } from '../../util'
 import { ItemCost } from '../item'
@@ -35,7 +36,9 @@ export abstract class Block extends UnlockableContent {
   static readonly codes = new Map<string, Block>()
 
   static fromCode(code: string): Block {
-    const block = this.codes.get(code)
+    type K = keyof typeof blockAliases
+    const id = code in blockAliases ? blockAliases[code as K] : code
+    const block = this.codes.get(id)
     if (block) {
       return block
     }

--- a/src/mindustry/block/helper.ts
+++ b/src/mindustry/block/helper.ts
@@ -40,3 +40,59 @@ export enum BlockOutputDirection {
   right = 2 << 3,
   all = front | back | left | right,
 }
+
+/**
+ * Aliases that the game has for some blocks
+ */
+export const blockAliases = {
+  'dart-mech-pad': 'legacy-mech-pad',
+  'dart-ship-pad': 'legacy-mech-pad',
+  'javelin-ship-pad': 'legacy-mech-pad',
+  'trident-ship-pad': 'legacy-mech-pad',
+  'glaive-ship-pad': 'legacy-mech-pad',
+  'alpha-mech-pad': 'legacy-mech-pad',
+  'tau-mech-pad': 'legacy-mech-pad',
+  'omega-mech-pad': 'legacy-mech-pad',
+  'delta-mech-pad': 'legacy-mech-pad',
+
+  'draug-factory': 'legacy-unit-factory',
+  'spirit-factory': 'legacy-unit-factory',
+  'phantom-factory': 'legacy-unit-factory',
+  'wraith-factory': 'legacy-unit-factory',
+  'ghoul-factory': 'legacy-unit-factory-air',
+  'revenant-factory': 'legacy-unit-factory-air',
+  'dagger-factory': 'legacy-unit-factory',
+  'crawler-factory': 'legacy-unit-factory',
+  'titan-factory': 'legacy-unit-factory-ground',
+  'fortress-factory': 'legacy-unit-factory-ground',
+
+  'mass-conveyor': 'payload-conveyor',
+  vestige: 'scepter',
+  'turbine-generator': 'steam-generator',
+
+  rocks: 'stone-wall',
+  sporerocks: 'spore-wall',
+  icerocks: 'ice-wall',
+  dunerocks: 'dune-wall',
+  sandrocks: 'sand-wall',
+  shalerocks: 'shale-wall',
+  snowrocks: 'snow-wall',
+  saltrocks: 'salt-wall',
+  dirtwall: 'dirt-wall',
+
+  ignarock: 'basalt',
+  holostone: 'dacite',
+  'holostone-wall': 'dacite-wall',
+  rock: 'boulder',
+  snowrock: 'snow-boulder',
+  cliffs: 'stone-wall',
+  craters: 'crater-stone',
+  deepwater: 'deep-water',
+  water: 'shallow-water',
+  slag: 'molten-slag',
+
+  cryofluidmixer: 'cryofluid-mixer',
+  'block-forge': 'constructor',
+  'block-unloader': 'payload-unloader',
+  'block-loader': 'payload-loader',
+}


### PR DESCRIPTION
Mindustry has aliases for some blocks when decoding schematics such as:
`water` -> `shallow-water`
`deepwater` -> `deep-water`

This pull request adds support for such aliases